### PR TITLE
Fixed small mistake and hotfixed FTP problem

### DIFF
--- a/src/autosaveworld/features/backup/ftp/FTPVirtualFileSystem.java
+++ b/src/autosaveworld/features/backup/ftp/FTPVirtualFileSystem.java
@@ -61,7 +61,17 @@ public class FTPVirtualFileSystem extends VirtualFileSystem {
 	public boolean exists(String path) throws IOException {
 		//there is no standard way to check if path exists
 		//list files and use contains check, that may take a lot of time
-		return getEntries().contains(path);
+		
+		Set<String> directory_list = getEntries();
+		
+		if (directory_list.contains(path)) // traditional check
+			return true;
+			
+		for (String list_element : directory_list) // maybe it's listing absolute?
+			if (list_element.substring(list_element.lastIndexOf("/")+1).equals(path))
+				return true;	
+		
+		return false;
 	}
 
 	@Override

--- a/src/autosaveworld/features/backup/utils/virtualfilesystem/VirtualFileSystem.java
+++ b/src/autosaveworld/features/backup/utils/virtualfilesystem/VirtualFileSystem.java
@@ -44,7 +44,7 @@ public abstract class VirtualFileSystem {
 			if (!exists(path)) {
 				createDirectory0(path);	
 			}
-			enterDirectory0(dirname);
+			enterDirectory0(path);
 			createdCount++;
 		}
 		while (createdCount-- > 0) {


### PR DESCRIPTION
Hey there!

I've encountered some problems backing up to a server that uses absolute paths instead of relative in the directory listing. This is not a 100% perfect solution, not even best performance, so please revise it.

I've also found a small mistake in VirtualFileSystem.java that caused random directories to be created in the target folder.