### PR TITLE
Replace File.seperator with '/' in ZipUtils

### DIFF
--- a/src/autosaveworld/features/backup/utils/ZipUtils.java
+++ b/src/autosaveworld/features/backup/utils/ZipUtils.java
@@ -59,7 +59,7 @@ public class ZipUtils {
 			File srcFile = new File(zipDir, child);
 
 			if (srcFile.isDirectory()) {
-				if (!BackupUtils.isFolderExcluded(excludefolders, srcDir.getName() + '/' + currentDir + child)) {
+				if (!BackupUtils.isFolderExcluded(excludefolders, srcDir.getName() + File.separator + currentDir + child)) {
 					zipDir(excludefolders, zipOutStream, srcDir, currentDir + child + '/');
 				}
 			} else {

--- a/src/autosaveworld/features/backup/utils/ZipUtils.java
+++ b/src/autosaveworld/features/backup/utils/ZipUtils.java
@@ -59,11 +59,11 @@ public class ZipUtils {
 			File srcFile = new File(zipDir, child);
 
 			if (srcFile.isDirectory()) {
-				if (!BackupUtils.isFolderExcluded(excludefolders, srcDir.getName() + File.separator + currentDir + child)) {
-					zipDir(excludefolders, zipOutStream, srcDir, currentDir + child + File.separator);
+				if (!BackupUtils.isFolderExcluded(excludefolders, srcDir.getName() + '/' + currentDir + child)) {
+					zipDir(excludefolders, zipOutStream, srcDir, currentDir + child + '/');
 				}
 			} else {
-				zipFile(zipOutStream, srcFile, srcDir.getName() + File.separator + currentDir + child);
+				zipFile(zipOutStream, srcFile, srcDir.getName() + '/' + currentDir + child);
 			}
 		}
 	}


### PR DESCRIPTION
We recognized the following rare issue: 
If AutoSaveWorld is run on a windows server the systems file separator is `\` and therfore all backup files are created with that file separator.
If those zip files are then opened on an UNIX based system this can result in some errors,

Also the [.zip file specification](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) is pretty clear about the naming of zip entries:

>4.4.17.1 The name of the file, with optional relative path. 
>The path stored MUST not contain a drive or device letter, or a leading slash.  
>All slashes  MUST be forward slashes '/' as opposed to backwards slashes '\' for compatibility with Amiga and UNIX file systems etc. 
>If input came from standard input, there is no file name field.  

Therfore I did this change.

Thanks for creating this great plugin! 👍 
