### PR TITLE
Possible fix for 1.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ target/
 *.project
 *.classpath
 *.prefs
+*.iml
+.idea/

--- a/src/autosaveworld/features/save/AutoSaveThread.java
+++ b/src/autosaveworld/features/save/AutoSaveThread.java
@@ -132,7 +132,9 @@ public class AutoSaveThread extends IntervalTaskThread {
 			try {
 				Object worldserver = getNMSWorld(world);
 				// invoke saveLevel method which waits for all chunks to save and than dumps RegionFileCache
-				ReflectionUtils.getMethod(worldserver.getClass(), NMSNames.getSaveLevelMethodName(), 0).invoke(worldserver);
+				//ReflectionUtils.getMethod(worldserver.getClass(), NMSNames.getSaveLevelMethodName(), 0).invoke(worldserver);
+				Object dataManager = ReflectionUtils.getMethod(worldserver.getClass(), "getDataManager", 0).invoke(worldserver);
+				ReflectionUtils.getMethod(dataManager.getClass(), "a", 0).invoke(dataManager);
 			} catch (Exception e) {
 				MessageLogger.exception("Could not dump RegionFileCache", e);
 			}


### PR DESCRIPTION
It appears that `saveLevel()` is absent from `WorldServer.java` in 1.13. All I've done is take what `saveLevel()` was doing which is `this.dataManager.a()` and have the reflection util get the dataManager object and invoke the `a()` method on it. 

I am of course very new to reflection but after some basic testing, I am no longer getting any errors in console. I hope I've called everything correctly and this results in proper saving. Please advise! 