### PR TITLE
Add config option for auto save

### DIFF
--- a/src/autosaveworld/config/AutoSaveWorldConfig.java
+++ b/src/autosaveworld/config/AutoSaveWorldConfig.java
@@ -41,6 +41,8 @@ public class AutoSaveWorldConfig implements Config {
 	@ConfigOption(path = "var.commandsonlyfromconsole")
 	public boolean commandOnlyFromConsole = false;
 	// save
+	@ConfigOption(path = "save.enabled")
+	public boolean saveEnabled = true;
 	@ConfigOption(path = "save.interval")
 	public int saveInterval = 900;
 	@ConfigOption(path = "save.broadcast")

--- a/src/autosaveworld/features/save/AutoSaveThread.java
+++ b/src/autosaveworld/features/save/AutoSaveThread.java
@@ -41,6 +41,8 @@ public class AutoSaveThread extends IntervalTaskThread {
 
 	@Override
 	public void onStart() {
+		if (!AutoSaveWorld.getInstance().getMainConfig().saveEnabled)
+			return;
 		//disable bukkit built-in autosave
 		try {
 			Server server = Bukkit.getServer();
@@ -52,7 +54,7 @@ public class AutoSaveThread extends IntervalTaskThread {
 
 	@Override
 	public boolean isEnabled() {
-		return true;
+		return AutoSaveWorld.getInstance().getMainConfig().saveEnabled;
 	}
 
 	@Override


### PR DESCRIPTION
This auto save is inefficient in newer minecraft versions, it pretty much causes lag spikes in newer versions compared to default paper. But since this plugin still has many other good features i think it would be nice for this to be configurable.